### PR TITLE
Feature/validation pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,69 +1,55 @@
 #!groovy
 
-node('master') {
-
-    currentBuild.result = "SUCCESS"
-
-    try {
-
-       stage 'Checkout'
-
-            echo 'Fetching the latest version'
-            checkout scm
-
-       stage 'Test'
-
-            echo 'Testing the code'
-            sh 'make install'
-            sh 'make test'
-
-       stage 'Deploy'
-            if (currentBuild.result == 'SUCCESS') {
-                if (BRANCH_NAME=='master') {
-                    withCredentials([string(credentialsId: 'DEPLOYMENT_PROD_TARGET_PATH', variable: 'DEPLOYMENT_TARGET_PATH')]) {
-                        echo 'Build project and deploy it live'
-                        sh 'make deploy_prod'
-                    }
-                } else {
-                    withCredentials([string(credentialsId: 'DEPLOYMENT_FEATURE_TARGET_PATH', variable: 'DEPLOYMENT_TARGET_PATH_BASE')]) {
-                        echo 'Build project and deploy it in a feature branch'
-                        sh 'DEPLOYMENT_TARGET_PATH=$DEPLOYMENT_TARGET_PATH_BASE/${BRANCH_NAME} make deploy_prod'
-                    }
-                }
-            } else {
-                echo 'Not deploying this build because it failed'
-            }
-
-       stage 'Validation'
-
-            if (currentBuild.result == 'SUCCESS' && BRANCH_NAME!='master') {
-                input message: 'Est-ce que la fonctionnalité fonctionne correctement sur https://zoupam-features.occi.tech/${BRANCH_NAME} ?', ok: 'Je valide !'
-            }
-
-       stage 'Cleanup'
-
-            echo 'Cleaning things up'
-            sh 'docker-compose run --rm --entrypoint rm elm -rf elm-stuff node_modules'
-            // mail body: 'project build successful',
-            //             from: 'xxxx@yyyyy.com',
-            //             replyTo: 'xxxx@yyyy.com',
-            //             subject: 'project build successful',
-            //             to: 'yyyyy@yyyy.com'
-
-        }
-
-
-    catch (err) {
-
-        currentBuild.result = "FAILURE"
-
-            // mail body: "project build error is here: ${env.BUILD_URL}" ,
-            // from: 'jennie@occitech.fr',
-            // replyTo: 'tracking@occitech.fr',
-            // subject: '[Zoupam] Project build failed',
-            // to: 'pierre@occitech.fr'
-
-        throw err
+stage('Checkout') {
+    node {
+        echo 'Fetching the latest version'
+        checkout scm
     }
+}
 
+stage('Test') {
+    node {
+        echo 'Testing the code'
+        sh 'make install'
+        sh 'make test'
+    }
+}
+
+stage('Deploy') {
+    node {
+        if (BRANCH_NAME=='master') {
+            withCredentials([string(credentialsId: 'DEPLOYMENT_PROD_TARGET_PATH', variable: 'DEPLOYMENT_TARGET_PATH')]) {
+                echo 'Build project and deploy it live'
+                sh 'make deploy_prod'
+            }
+        } else {
+            withCredentials([string(credentialsId: 'DEPLOYMENT_FEATURE_TARGET_PATH', variable: 'DEPLOYMENT_TARGET_PATH_BASE')]) {
+                echo 'Build project and deploy it in a feature branch'
+                sh 'DEPLOYMENT_TARGET_PATH=$DEPLOYMENT_TARGET_PATH_BASE/${BRANCH_NAME} make deploy_prod'
+            }
+        }
+    }
+}
+
+stage('Validation') {
+    echo 'BRANCHE ${BRANCH_NAME}'
+    if (BRANCH_NAME=='master') {
+        echo 'Rien à faire, cela a été validé sur la branche ...'
+    } else {
+        milestone()
+        input message: "Est-ce que la fonctionnalité fonctionne correctement sur https://zoupam-features.occi.tech/${BRANCH_NAME} ?", ok: 'Je valide !'
+        milestone()
+    }
+}
+
+stage('Cleanup') {
+    node {
+        echo 'Cleaning things up'
+        sh 'docker-compose run --rm --entrypoint rm elm -rf elm-stuff node_modules'
+        // mail body: 'project build successful',
+        //             from: 'xxxx@yyyyy.com',
+        //             replyTo: 'xxxx@yyyy.com',
+        //             subject: 'project build successful',
+        //             to: 'yyyyy@yyyy.com'
+    }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,11 +34,16 @@ node('master') {
                 echo 'Not deploying this build because it failed'
             }
 
+       stage 'Validation'
+
+            if (currentBuild.result == 'SUCCESS' && BRANCH_NAME!='master') {
+                input message: 'Est-ce que la fonctionnalité fonctionne correctement sur https://zoupam-features.occi.tech/${BRANCH_NAME} ?', ok: 'Je valide !'
+            }
+
        stage 'Cleanup'
 
             echo 'Cleaning things up'
             sh 'docker-compose run --rm --entrypoint rm elm -rf elm-stuff node_modules'
-
             // mail body: 'project build successful',
             //             from: 'xxxx@yyyyy.com',
             //             replyTo: 'xxxx@yyyy.com',


### PR DESCRIPTION
Ajout d'une étape de validation manuelle pour la validation interne de la fonctionnalité
 
![selection_012](https://cloud.githubusercontent.com/assets/75968/22005146/506cd0ec-dc61-11e6-8729-2c7aac66f302.png)

Je ne suis pas parvenu à supprimer intégralement le dossier lors du cleanup, ainsi chaque build laisse un dossier vide.
Si quelqu'un a une idée pour arriver à supprimer tout un dossier sachant que j'ai 2 variables du type `user@ssh-host:base/path` et `branche/name` ... L'idéal serait de faire un `ssh user@ssh-host "rm -rf base/path/branche/name"` mais je n'y suis pas parvenu ! (ping @cypx :roll_eyes: )